### PR TITLE
Bugfix: Allow replacing cached items

### DIFF
--- a/lib/LRUCacheProxy.js
+++ b/lib/LRUCacheProxy.js
@@ -28,7 +28,7 @@ var LRUCacheProxy = function LRUCacheProxy(options) {
 			var lruGet = LRUCache.prototype.get;
 
 			lru.get = function(key, callback) {
-				callback(lruGet.apply(lru, arguments));
+				callback && callback(lruGet.apply(lru, arguments));
 			};
 
 			return lru;


### PR DESCRIPTION
Fixes the issue where in some use cases an error was thrown when replacing a previously set item.

Reproduce with:
    var Cache = require( "lru-cache-cluster" )();
    Cache.set('test', 1);
    Cache.set('test', 2);

Result:
    TypeError: undefined is not a function
