### PR TITLE
Update lru-cache dependency & fix tests

### DIFF
--- a/lib/LRUCacheProxy.js
+++ b/lib/LRUCacheProxy.js
@@ -43,7 +43,11 @@ var LRUCacheProxy = function LRUCacheProxy(options) {
 };
 
 LRUCacheProxy.prototype.get = function(key, callback) {
-	var failSafe = setTimeout(function() { failSafe = undefined; callback(undefined); }, 100);
+       if (typeof callback !== 'function') {
+         throw new Error('missing required callback function');
+       }
+
+       var failSafe = setTimeout(function() { failSafe = undefined; callback(undefined); }, 100);
 
 	send(this.namespace, 'get', key, function(result) {
 		if(!failSafe) return;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "tap": "~0.4.8"
   },
   "scripts": {
-    "test": "tap test"
+    "test": "tap test/clustered.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/robby/node-lru-cache-cluster",
   "dependencies": {
-    "lru-cache": "~2.5.0",
+    "lru-cache": "~3.2.0",
     "node-uuid": "~1.4.1"
   }
 }

--- a/test/clustered.js
+++ b/test/clustered.js
@@ -2,9 +2,9 @@ var cluster = require('cluster');
 var LRUCacheCluster = require('../');
 
 cluster.setupMaster({
-		exec : 'worker',
-		args : process.argv,
-		silent : false
+    exec : 'worker',
+    args : process.argv,
+    silent : false
 });
 
 cluster.fork();

--- a/test/worker.js
+++ b/test/worker.js
@@ -25,7 +25,7 @@ function checkCache(username) {
     else {
       console.timeEnd('checking cache for ' + username, profile);
     }
-  });  
+  });
 }
 
 setTimeout(function(){
@@ -33,7 +33,7 @@ setTimeout(function(){
   checkCache('michael');
   checkCache('steve');
 
-  setTimeout(function(){ 
+  setTimeout(function(){
     checkCache('robby'); checkCache('michael'); checkCache('steve');
 
     setTimeout(function(){ process.exit(); }, 2000);
@@ -43,6 +43,8 @@ setTimeout(function(){
 var test = require('tap').test;
 
 test("basic", function (t) {
+  t.plan(2);
+
   var cache = new LRU({max: 10})
   cache.set("key", "value")
 
@@ -53,11 +55,11 @@ test("basic", function (t) {
   cache.get('nada', function(value) {
     t.equal(value, undefined);
   });
-
-  setTimeout(function(){ t.end(); }, 1000);
 })
 
 test("least recently set", function (t) {
+  t.plan(3);
+
   var cache = new LRU(2)
   cache.set("a", "A")
   cache.set("b", "B")
@@ -74,15 +76,15 @@ test("least recently set", function (t) {
   cache.get('a', function(value) {
     t.equal(value, undefined);
   });
-
-  setTimeout(function(){ t.end(); }, 1000);
 })
 
 test("lru recently gotten", function (t) {
+  t.plan(3);
+
   var cache = new LRU(2)
   cache.set("a", "A")
   cache.set("b", "B")
-  cache.get("a")
+  cache.get("a", function(){})
   cache.set("c", "C")
 
   cache.get('c', function(value) {
@@ -96,6 +98,8 @@ test("lru recently gotten", function (t) {
   cache.get('a', function(value) {
     t.equal(value, 'A');
   });
-
-  setTimeout(function(){ t.end(); }, 1000);
 })
+
+test('quit worker', function(){
+  process.exit(0);
+});


### PR DESCRIPTION
The old `lru-cache` version doesn't perform well on >= Node4. This PR updates this dependency and gets the tests running.
